### PR TITLE
fix(npm): Support React Native up to 0.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "react": "^16.0",
-    "react-native": "^0.57.0"
+    "react-native": ">=0.57 <0.60"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
Currently if i use with react native 0.59.0 yarn will warn about unmet dependencies due to peerDependencies for react native includes only `^0.57`

# Note
React Native 0.59 has just released.

No breaking change for Image Editor (Image Store still remain in react native)