### PR TITLE
fix(typings): Wrong type for ImageCropData.resizeMode

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -28,11 +28,7 @@ export type ImageCropData = {
    * (Optional) the resizing mode to use when scaling the image. If the
    * `displaySize` param is not specified, this has no effect.
    */
-  resizeMode?: $Maybe<{
-    contain: string,
-    cover: string,
-    stretch: string,
-  }>,
+  resizeMode?: $Maybe<"contain" | "cover" | "stretch">,
 };
 
 declare class ImageEditor {


### PR DESCRIPTION
Current typing for ImageCropData.resizeMode is wrong
Currently it typed as object instead of string of ("contain" | "cover" | "stretch")

# Note
typings is not included in current npm release