### PR TITLE
fix(ios) Can't compile when link with pod

### DIFF
--- a/ios/RNCImageEditor.m
+++ b/ios/RNCImageEditor.m
@@ -15,7 +15,11 @@
 
 #import <React/RCTImageLoader.h>
 #import <React/RCTImageStoreManager.h>
+#if __has_include(<RCTImage/RCTImageUtils.h>)
 #import <RCTImage/RCTImageUtils.h>
+#else
+#import "RCTImageUtils.h"
+#endif
 
 @implementation RNCImageEditor
 

--- a/react-native-image-editor.podspec
+++ b/react-native-image-editor.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
+  s.dependency 'React/RCTImage'
 end


### PR DESCRIPTION
Project link with CocoaPods can't compile due to can't find `<RCTImage/RCTImageUtils.h>`

Sorry that I didn't test before submit #15
I verified that my CI is green before submit this PR.
I also test with new project without cocoa pod.