### PR TITLE
fix(android): Wrong sample size exit logic

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModule.java
+++ b/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModule.java
@@ -510,7 +510,7 @@ public class ImageEditorModule extends ReactContextBaseJavaModule {
    */
   private static int getDecodeSampleSize(int width, int height, int targetWidth, int targetHeight) {
     int inSampleSize = 1;
-    if (height > targetWidth || width > targetHeight) {
+    if (height > targetHeight || width > targetWidth) {
       int halfHeight = height / 2;
       int halfWidth = width / 2;
       while ((halfWidth / inSampleSize) >= targetWidth


### PR DESCRIPTION
Reference: https://developer.android.com/topic/performance/graphics/load-bitmap