### PR TITLE
fix: Add missing ContentResolver scheme

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModule.java
+++ b/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModule.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import android.annotation.SuppressLint;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -56,7 +57,10 @@ public class ImageEditorModule extends ReactContextBaseJavaModule {
   protected static final String NAME = "RNCImageEditor";
 
   private static final List<String> LOCAL_URI_PREFIXES = Arrays.asList(
-      "file://", "content://");
+          ContentResolver.SCHEME_FILE,
+          ContentResolver.SCHEME_CONTENT,
+          ContentResolver.SCHEME_ANDROID_RESOURCE
+  );
 
   private static final String TEMP_FILE_PREFIX = "ReactNative_cropped_image_";
 


### PR DESCRIPTION
# Summary

This library is using ContentProvider on Android as a mean to read image data and as such should accept all schemes handled by ContentProvider. Before this PR only URIs with file and content schemas were recognized as local URIs . This PR adds android.resource scheme what enables us to read apps resources.

## Test Plan

1. Try to read any app asset such as "android.resource://<app-package-name>/drawable/<some-image-name>.png"

### What's required for testing (prerequisites)?

Adding some android asset to the app and trying to crop it.

### What are the steps to reproduce (after prerequisites)?
1. Try to read any app asset such as "android.resource://<app-package-name>/drawable/<some-image-name>.png"
EX: User is able to read that asset
AR: User is not able to read that asset
## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅   |

## Checklist
- [X ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
