### PR TITLE
feat: make it possible to crop transparent images on ios

### DIFF
--- a/ios/RNCImageEditor.m
+++ b/ios/RNCImageEditor.m
@@ -74,7 +74,7 @@ RCT_EXPORT_METHOD(cropImage:(NSURLRequest *)imageRequest
     // Store image
     NSString *path = [RNCFileSystem generatePathInDirectory:[[RNCFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"ReactNative_cropped_image_"] withExtension:@".jpg"];
 
-    NSData *imageData = UIImageJPEGRepresentation(croppedImage, 1);
+    NSData *imageData = UIImagePNGRepresentation(croppedImage);
     NSError *writeError;
     NSString *uri = [RNCImageUtils writeImage:imageData toPath:path error:&writeError];
       


### PR DESCRIPTION
Fixes #37 This PR makes it possible to crop transparent images on ios with preserving transparent background. On Android it's already supported.